### PR TITLE
Fix NullPointerException on export

### DIFF
--- a/src/main/java/it/damore/solr/importexport/App.java
+++ b/src/main/java/it/damore/solr/importexport/App.java
@@ -305,7 +305,7 @@ public class App {
             }
             pw.write("\n");
           }
-          if (cursorMark.equals(nextCursorMark)) {
+          if (nextCursorMark==null || cursorMark.equals(nextCursorMark)) {
             done = true;
           }
 


### PR DESCRIPTION
This fixes an NPE on export when exporting from SOLR server v4.6.1:
Exception in thread "main" java.lang.NullPointerException
	at it.damore.solr.importexport.App.readAllDocuments(App.java:308)
	at it.damore.solr.importexport.App.main(App.java:110)