### PR TITLE
 Allow to commit during import and set start point of import

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ import documents from json but first delete all documents in the collection
 export documents and skip few fields. In the example the will be skipped the fields: `field1_a`, all the fields starting with `field2_` and all the fields ending with `_date`
 
      ./run.sh -s http://localhost:8983/solr/collection -a export -o /tmp/collection.json --skipFields field1_a,field2_*,*_date
+
+Import documents, skip first 49835000 records from file, commit every 200000 documents, block size 5000 (faster than default 500) 
+
+    ./run.sh -s http://localhost:8983/solr/collection -a import -o /tmp/collection.json -x 49835000 -c 200000 -b 5000 

--- a/src/main/java/it/damore/solr/importexport/config/CommandLineConfig.java
+++ b/src/main/java/it/damore/solr/importexport/config/CommandLineConfig.java
@@ -66,6 +66,8 @@ public class CommandLineConfig {
   private String filterQuery;
   private String uniqueKey;
   private Boolean dryRun;
+  private long skipCount;
+  private Integer commitAfter;
   private int blockSize = DEFAULT_BLOCK_SIZE;
   private String dateTimeFormat = DEFAULT_DATETIME_FORMAT;
   /**
@@ -214,6 +216,23 @@ public class CommandLineConfig {
   public void setDateTimeFormat(String dateTimeFormat)
   {
     this.dateTimeFormat = dateTimeFormat;
+  }
+
+  public long getSkipCount() {
+    return skipCount;
+  }
+
+  public void setSkipCount(long skipCount) {
+    this.skipCount = skipCount;
+  }
+
+
+  public Integer getCommitAfter() {
+    return commitAfter;
+  }
+
+  public void setCommitAfter(Integer commitAfter) {
+    this.commitAfter = commitAfter;
   }
 
   /* (non-Javadoc)

--- a/src/main/java/it/damore/solr/importexport/config/ConfigFactory.java
+++ b/src/main/java/it/damore/solr/importexport/config/ConfigFactory.java
@@ -1,8 +1,7 @@
 package it.damore.solr.importexport.config;
 
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
+import it.damore.solr.importexport.config.CommandLineConfig.ActionType;
+import it.damore.solr.importexport.config.SkipField.MatchType;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -13,14 +12,16 @@ import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import it.damore.solr.importexport.config.CommandLineConfig.ActionType;
-import it.damore.solr.importexport.config.SkipField.MatchType;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class ConfigFactory {
 
   private static Logger         logger          = LoggerFactory.getLogger(ConfigFactory.class);
 
   private static final String[] BLOCK_SIZE      = new String[] {"b", "blockSize"};
+  private static final String[] SKIP_DOCS      = new String[] {"x", "skipCount"};
+  private static final String[] COMMIT_DURING_WORK      = new String[] {"c", "commitDuringImport"};
   private static final String[] SOLR_URL        = new String[] {"s", "solrUrl"};
   private static final String[] ACTION_TYPE     = new String[] {"a", "actionType"};
   private static final String[] OUTPUT          = new String[] {"o", "output"};
@@ -52,6 +53,8 @@ public class ConfigFactory {
     Boolean dryRun = cmd.hasOption(DRY_RUN[1]);
     String actionType = cmd.getOptionValue(ACTION_TYPE[1]);
     String blockSize = cmd.getOptionValue(BLOCK_SIZE[1]);
+    String skipCount = cmd.getOptionValue(SKIP_DOCS[1]);
+    String commitAfter = cmd.getOptionValue(COMMIT_DURING_WORK[1]);
     String dateTimeFormat = cmd.getOptionValue(DATETIME_FORMAT[1]);
 
     if (actionType == null) {
@@ -103,6 +106,13 @@ public class ConfigFactory {
     c.setDeleteAll(deleteAll);
 
     c.setDryRun(dryRun);
+    if (skipCount != null) {
+      c.setSkipCount(Long.valueOf(skipCount));
+    }
+
+    if (commitAfter != null) {
+      c.setCommitAfter(Integer.valueOf(commitAfter));
+    }
 
     if (blockSize != null) {
       c.setBlockSize(Integer.parseInt(blockSize));
@@ -137,6 +147,11 @@ public class ConfigFactory {
     cliOptions.addOption(SKIP_FIELDS[0], SKIP_FIELDS[1], true,
                          "comma separated fields list to skip during export/import, this field accepts start and end wildcard *. So you can specify skip all fields starting with name_*");
     cliOptions.addOption(BLOCK_SIZE[0], BLOCK_SIZE[1], true, "block size (default " + CommandLineConfig.DEFAULT_BLOCK_SIZE + " documents)");
+    cliOptions.addOption(SKIP_DOCS[0], SKIP_DOCS[1], true, "Number of documents to be skipped when loading from file. Useful when an error occurs, " +
+        "so loading can continue from last successful save." +
+        " ");
+    cliOptions.addOption(COMMIT_DURING_WORK[0], COMMIT_DURING_WORK[1], true, "Commit progress after specified number of docs. If not specified, " +
+        "whole work will be committed.");
     cliOptions.addOption(DATETIME_FORMAT[0], DATETIME_FORMAT[1], true, "set custom DateTime format (default " + CommandLineConfig.DEFAULT_DATETIME_FORMAT + " )");
     cliOptions.addOption(HELP[0], HELP[1], false, "help");
     CommandLineParser parser = new DefaultParser();


### PR DESCRIPTION
During import of cca 70M of documents, where json file was aprox 140GB, there occurred Timeout exception (10minutes of inactivity).
I tried to fix this (probably did not succeeded) by more commits during import (c parameter). Also I needed to continue from last successfully saved document, (x parameter). This allows you to continue when an error appears.

As side effect of SolrServerException (timeout) I added 5 retries.