### PR TITLE
disabling timeAllowed when using cursorMark. 

### DIFF
--- a/src/main/java/it/damore/solr/importexport/App.java
+++ b/src/main/java/it/damore/solr/importexport/App.java
@@ -284,6 +284,7 @@ public class App {
   private static void readAllDocuments(HttpSolrClient client, File outputFile) throws SolrServerException, IOException {
 
     SolrQuery solrQuery = new SolrQuery();
+    solrQuery.setTimeAllowed(-1);
     solrQuery.setQuery("*:*");
     if (config.getFilterQuery() != null) {
       solrQuery.addFilterQuery(config.getFilterQuery());


### PR DESCRIPTION
This basically avoids  "Can not search using both cursorMark and timeAllowed" error.

for more information: https://stackoverflow.com/questions/24503620/why-cursormark-and-timeallowed-cannot-be-used-together