### PR TITLE
call solrQuery.setFields('*') in export

### DIFF
--- a/src/main/java/it/damore/solr/importexport/App.java
+++ b/src/main/java/it/damore/solr/importexport/App.java
@@ -286,6 +286,7 @@ public class App {
     SolrQuery solrQuery = new SolrQuery();
     solrQuery.setTimeAllowed(-1);
     solrQuery.setQuery("*:*");
+    solrQuery.setFields("*");
     if (config.getFilterQuery() != null) {
       solrQuery.addFilterQuery(config.getFilterQuery());
     }


### PR DESCRIPTION
First, thanks for sharing this!

The change sets fields to be retrieved to '*' (equals to setting "fl" to "*" in solr GUI).
Without it, the backup/export is missing the real data.