### PR TITLE
.semver:patch Adds auth fixes when importing & exporting the collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,18 @@
                   <filter>
                         <artifact>*:*</artifact>
                         <excludes>
+                           <exclude>META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder</exclude>
+                           <exclude>META-INF/io.netty.versions.properties</exclude>
+                           <exclude>META-INF/DEPENDENCIES</exclude>
+                           <exclude>META-INF/LICENSE</exclude>
+                           <exclude>META-INF/NOTICE</exclude>
+                           <exclude>**/*.txt</exclude>
+                           <exclude>**/*.html</exclude>
                            <exclude>META-INF/*.SF</exclude>
+                           <exclude>META-INF/*.MF</exclude>
                            <exclude>META-INF/*.DSA</exclude>
                            <exclude>META-INF/*.RSA</exclude>
+                           <exclude>module-info.class</exclude>
                         </excludes>
                   </filter>
                </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -1,152 +1,164 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-   <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-   <groupId>it.damore.solr</groupId>
-   <artifactId>import-export</artifactId>
-   <version>1.0</version>
-   <packaging>jar</packaging>
+	<groupId>it.damore.solr</groupId>
+	<artifactId>import-export</artifactId>
+	<version>1.0</version>
+	<packaging>jar</packaging>
 
-   <name>import-export</name>
-   <url>http://maven.apache.org</url>
+	<name>import-export</name>
+	<url>http://maven.apache.org</url>
 
-   <properties>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <solr.version>8.5.0</solr.version>
-      <jackson-databind.version>[2.9.9,)</jackson-databind.version>
-      <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>
-      <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-      <commons-cli.version>1.4</commons-cli.version>
-      <commons-codec.version>1.14</commons-codec.version>
-   </properties>
-   <build>
-      <resources>
-         <resource>
-            <directory>src/main/java</directory>
-            <includes>
-               <include>**/*.properties</include>
-            </includes>
-         </resource>
-         <resource>
-            <directory>src/main/resources</directory>
-            <includes>
-               <include>**/*.xml</include>
-            </includes>
-         </resource>
-      </resources>
-      <plugins>
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>${maven-compiler-plugin.version}</version>
-            <configuration>
-               <source>1.8</source>
-               <target>1.8</target>
-               <showDeprecation>true</showDeprecation>
-            </configuration>
-         </plugin>
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>${maven-shade-plugin.version}</version>
-            <executions>
-               <execution>
-                  <phase>package</phase>
-                  <goals>
-                  <goal>shade</goal>
-                  </goals>
-                  <configuration>
-                  <finalName>solr-import-export-${project.version}</finalName>
-                  <transformers>
-                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                        <mainClass>it.damore.solr.importexport.App</mainClass>
-                     </transformer>
-                  </transformers>
-                  </configuration>
-               </execution>
-            </executions>
-            <configuration>
-               <filters>
-                  <filter>
-                        <artifact>*:*</artifact>
-                        <excludes>
-                           <exclude>META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder</exclude>
-                           <exclude>META-INF/io.netty.versions.properties</exclude>
-                           <exclude>META-INF/DEPENDENCIES</exclude>
-                           <exclude>META-INF/LICENSE</exclude>
-                           <exclude>META-INF/NOTICE</exclude>
-                           <exclude>**/*.txt</exclude>
-                           <exclude>**/*.html</exclude>
-                           <exclude>META-INF/*.SF</exclude>
-                           <exclude>META-INF/*.MF</exclude>
-                           <exclude>META-INF/*.DSA</exclude>
-                           <exclude>META-INF/*.RSA</exclude>
-                           <exclude>module-info.class</exclude>
-                        </excludes>
-                  </filter>
-               </filters>
-            </configuration>
-         </plugin>
+	<repositories>
+		<repository>
+			<id>maven-restlet</id>
+			<name>Public online Restlet repository</name>
+			<url>https://maven.restlet.talend.com</url>
+		</repository>
+	</repositories>
 
-      </plugins>
-   </build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<solr.version>8.5.0</solr.version>
+		<jackson-databind.version>[2.9.9,)</jackson-databind.version>
+		<maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>
+		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+		<commons-cli.version>1.4</commons-cli.version>
+		<commons-codec.version>1.14</commons-codec.version>
+	</properties>
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/java</directory>
+				<includes>
+					<include>**/*.properties</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+				<includes>
+					<include>**/*.xml</include>
+				</includes>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven-compiler-plugin.version}</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<showDeprecation>true</showDeprecation>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>${maven-shade-plugin.version}</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>solr-import-export-${project.version}</finalName>
+							<transformers>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>it.damore.solr.importexport.App</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<filters>
+						<filter>
+							<artifact>*:*</artifact>
+							<excludes>
+								<exclude>META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder</exclude>
+								<exclude>META-INF/io.netty.versions.properties</exclude>
+								<exclude>META-INF/DEPENDENCIES</exclude>
+								<exclude>META-INF/LICENSE</exclude>
+								<exclude>META-INF/NOTICE</exclude>
+								<exclude>**/*.txt</exclude>
+								<exclude>**/*.html</exclude>
+								<exclude>META-INF/*.SF</exclude>
+								<exclude>META-INF/*.MF</exclude>
+								<exclude>META-INF/*.DSA</exclude>
+								<exclude>META-INF/*.RSA</exclude>
+								<exclude>module-info.class</exclude>
+							</excludes>
+						</filter>
+					</filters>
+				</configuration>
+			</plugin>
 
-   <dependencies>
-      <dependency>
-         <groupId>org.apache.solr</groupId>
-         <artifactId>solr-solrj</artifactId>
-         <version>${solr.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>ch.qos.logback</groupId>
-         <artifactId>logback-classic</artifactId>
-         <version>1.2.3</version>
-      </dependency>
-<!--      <dependency>-->
-<!--         <groupId>org.slf4j</groupId>-->
-<!--         <artifactId>log4j-over-slf4j</artifactId>-->
-<!--         <version>1.7.29</version>-->
-<!--      </dependency>-->
-<!--      &lt;!&ndash; http://mvnrepository.com/artifact/commons-logging/commons-logging &ndash;&gt;-->
-<!--      <dependency>-->
-<!--         <groupId>commons-logging</groupId>-->
-<!--         <artifactId>commons-logging</artifactId>-->
-<!--         <version>1.2</version>-->
-<!--      </dependency>-->
-<!--      &lt;!&ndash; https://mvnrepository.com/artifact/commons-codec/commons-codec &ndash;&gt;-->
-      <dependency>
-         <groupId>commons-codec</groupId>
-         <artifactId>commons-codec</artifactId>
-         <version>${commons-codec.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.eclipse.persistence</groupId>
-         <artifactId>org.eclipse.persistence.moxy</artifactId>
-         <version>2.7.6</version>
-      </dependency>
-      <dependency>
-         <groupId>commons-cli</groupId>
-         <artifactId>commons-cli</artifactId>
-         <version>${commons-cli.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>com.fasterxml.jackson.core</groupId>
-         <artifactId>jackson-databind</artifactId>
-         <version>${jackson-databind.version}</version>
-      </dependency>
+		</plugins>
+	</build>
 
-      <dependency>
-         <groupId>org.junit.jupiter</groupId>
-         <artifactId>junit-jupiter-api</artifactId>
-         <version>5.6.1</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.solr</groupId>
-         <artifactId>solr-test-framework</artifactId>
-         <version>${solr.version}</version>
-         <scope>test</scope>
-      </dependency>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.solr</groupId>
+			<artifactId>solr-solrj</artifactId>
+			<version>${solr.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.3</version>
+		</dependency>
+		<!-- <dependency> -->
+		<!-- <groupId>org.slf4j</groupId> -->
+		<!-- <artifactId>log4j-over-slf4j</artifactId> -->
+		<!-- <version>1.7.29</version> -->
+		<!-- </dependency> -->
+		<!-- &lt;!&ndash; http://mvnrepository.com/artifact/commons-logging/commons-logging 
+			&ndash;&gt; -->
+		<!-- <dependency> -->
+		<!-- <groupId>commons-logging</groupId> -->
+		<!-- <artifactId>commons-logging</artifactId> -->
+		<!-- <version>1.2</version> -->
+		<!-- </dependency> -->
+		<!-- &lt;!&ndash; https://mvnrepository.com/artifact/commons-codec/commons-codec 
+			&ndash;&gt; -->
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>${commons-codec.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.persistence</groupId>
+			<artifactId>org.eclipse.persistence.moxy</artifactId>
+			<version>2.7.6</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>${commons-cli.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson-databind.version}</version>
+		</dependency>
 
-   </dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.6.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.solr</groupId>
+			<artifactId>solr-test-framework</artifactId>
+			<version>${solr.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
 </project>

--- a/src/main/java/it/damore/solr/importexport/PreemptiveAuthInterceptor.java
+++ b/src/main/java/it/damore/solr/importexport/PreemptiveAuthInterceptor.java
@@ -1,0 +1,39 @@
+package it.damore.solr.importexport;
+
+import java.io.IOException;
+import java.net.http.HttpRequest;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.AuthState;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+
+/**
+ * https://github.com/freedev/solr-import-export-json/issues/43
+ * https://stackoverflow.com/questions/2014700/preemptive-basic-authentication-with-apache-httpclient-4/11868040#11868040
+ * 
+ * @author i.baricic
+ * @since 02.10.2020
+ */
+public class PreemptiveAuthInterceptor implements HttpRequestInterceptor {
+    
+    @Override
+    public void process(org.apache.http.HttpRequest request, HttpContext context) throws HttpException, IOException {
+        AuthState authState = (AuthState) context.getAttribute(HttpClientContext.TARGET_AUTH_STATE);
+        if (authState.getAuthScheme() == null) {
+            CredentialsProvider credsProvider = (CredentialsProvider) context.getAttribute(HttpClientContext.CREDS_PROVIDER);
+            HttpHost targetHost = (HttpHost) context.getAttribute(HttpCoreContext.HTTP_TARGET_HOST);
+            AuthScope authScope = new AuthScope(targetHost.getHostName(), targetHost.getPort());
+            Credentials creds = credsProvider.getCredentials(authScope);
+            authState.update(new BasicScheme(), creds);
+        }
+    }
+
+}

--- a/src/main/java/it/damore/solr/importexport/PreemptiveAuthInterceptor.java
+++ b/src/main/java/it/damore/solr/importexport/PreemptiveAuthInterceptor.java
@@ -1,7 +1,6 @@
 package it.damore.solr.importexport;
 
 import java.io.IOException;
-import java.net.http.HttpRequest;
 
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,7 +16,7 @@
 		<appender-ref ref="STDOUT" />
 	</logger>
 	<!-- By default, the level of the root level is set to DEBUG -->
-	<root level="INFO">
+	<root level="DEBUG">
 		<appender-ref ref="STDOUT" />
 	</root>
 </configuration>


### PR DESCRIPTION
- I had the same problems as described here; https://github.com/freedev/solr-import-export-json/issues/43
- I could solve them using the comments
- I see, the fixes have not yet been included in the master branch, hence my PR.
- I could access the restlet jars from default Maven central repository; therefore I have added the restlet repository to pom.xml